### PR TITLE
fix: charts wrong theme

### DIFF
--- a/frontend/scripts/main.js
+++ b/frontend/scripts/main.js
@@ -15,9 +15,8 @@ const solvedRatings = new SolvedRatings();
 const ratingHistory = new RatingHistory();
 
 document.addEventListener('DOMContentLoaded', () => {
-	const savedTheme = localStorage.getItem('theme') || 'theme-catppuccin';
-	root.classList.add(savedTheme);
-	themeSelect.value = savedTheme;
+	setTheme(localStorage.getItem('theme'));
+	themeSelect.value = localStorage.getItem('theme');
 
 	solvedTags.updateChart();
 	solvedRatings.updateChart();


### PR DESCRIPTION
Fixes #34
Problem:
The chart colors were not being updated after loading the theme initially.

Solution:
Use the already written setTheme function which handles this.