### PR TITLE
fix: hero graph overflowing into analytics

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -240,10 +240,14 @@ input.glow-interactive:focus {
 .hero-graph-container {
 	--graph-anim-delay: 250ms;
 
+	transform-origin: bottom;
+	bottom: 0;
+	left: 0;
 	position: absolute;
 	pointer-events: none;
 	width: 100%;
-	height: 100%;
+	height: auto;
+	min-height: 100%;
 }
 
 .hero-graph-container svg circle {


### PR DESCRIPTION
Fixes #56 
Made it stick to the bottom of the hero section, and overflow above the screen instead.