### PR TITLE
fix: loader background not transitioning

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -598,7 +598,6 @@ main h1 {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	transition-duration: var(--bg-transition-speed);
 }
 
 .loader::after,


### PR DESCRIPTION
Fixes #49 
The loader animation appeared slower than the other elements. Fixed it by removing the transition property of .loader and .loader-small, not completely sure why this worked.