### PR TITLE
fix: main background transition

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -432,6 +432,7 @@ div.theme-select {
 	padding: 3rem 0;
 	position: relative;
 	z-index: 0;
+	transition-duration: var(--bg-transition-speed);
 }
 
 main {


### PR DESCRIPTION
Fixes #86 
After making the updates to the hero section the background transition for the main section broke.
The previous "fix" (#85) did not actually fix this problem.