### PR TITLE
fix: wrong performance displayed for contest

### DIFF
--- a/frontend/src/analytics.js
+++ b/frontend/src/analytics.js
@@ -163,7 +163,7 @@ function updateSolvedRatingsTime(ratingsTime) {
 }
 
 function updatePerformance(performance) {
-	performance.sort((a, b) => a.timestamp > b.timestamp);
+	performance.sort((a, b) => a.timestamp - b.timestamp);
 
 	ratingHistory.updatePerfomanceData(performance);
 	ratingHistory.loading = false;


### PR DESCRIPTION
Fixes #136
The issue was JavaScript sort expects an integer, but a bool was being returned. This caused the sort to evaluate some items as equal, when they were not.