### PR TITLE
fix: cd into project dir when running fetch-contests.sh

### DIFF
--- a/scripts/fetch-contests.sh
+++ b/scripts/fetch-contests.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-docker compose run --build fetcher
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+docker compose run --build fetcher --remove-orphans
 
 echo "Cleaning up old images..."
 docker image prune -f


### PR DESCRIPTION
Closes #151 
Also add `--remove-orphans` to remove orphan containers when running the script.