### PR TITLE
fix: add margin above user-stats list

### DIFF
--- a/frontend/src/style/analytics.css
+++ b/frontend/src/style/analytics.css
@@ -65,7 +65,7 @@
 }
 
 #username {
-	font-size: 1.3em;
+	font-size: 1.4em;
 	margin-top: 0;
 	font-family: "Inconsolata", Courier, monospace;
 	color: var(--fg);
@@ -73,7 +73,7 @@
 
 #user-stats ul {
 	margin: 0;
-	margin-top: 10%;
+	margin-top: 20px;
 	padding-left: 0px;
 	list-style: disc inside;
 }


### PR DESCRIPTION
closes #177 
adds missing margin between hyperlink and list in user profile 