### PR TITLE
fix: flash of no theme before main.js executes

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -57,14 +57,14 @@
 
 	<section id="hero-section">
 		<header class="hero">
-			<h1 class="glow-text fade-in" style="animation-delay: 0.1s;">Codeforces<br>Insights</h1>
-			<p class="fade-in" style="animation-delay: 0.35s;">
+			<h1 class="glow-text fade-in" style="animation-delay: 0.25s;">Codeforces<br>Insights</h1>
+			<p class="fade-in" style="animation-delay: 0.5s;">
 				<span class="blue-text">Track</span> your rating progress,
 				<span class="blue-text">identify</span> your strengths and improvement opportunities,
 				and <span class="blue-text">discover</span> patterns that help you
 				<span class="aqua-text weight-450 glow-pulse">rank up faster</span>.
 			</p>
-			<div class="user-form-container fade-in" style="animation-delay: 0.5s;">
+			<div class="user-form-container fade-in" style="animation-delay: 0.75s;">
 				<h2 class="">
 					<span class="blue-text weight-450 glow-text">Analyze</span>
 					your Codeforces history now.

--- a/frontend/src/style/hero.css
+++ b/frontend/src/style/hero.css
@@ -92,7 +92,7 @@
 
 /* Hero graph animation */
 .hero-graph-container {
-	--graph-anim-delay: 250ms;
+	--graph-anim-delay: 800ms;
 
 	position: fixed;
 	pointer-events: none;


### PR DESCRIPTION
Fixes #170 
- Added blocking script to load theme before page is parsed.
- Added defer script to script tags.
- Made the fade-in animation delays consistent.