### PR TITLE
perf: speed up fft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ profile:
 	@docker run --rm \
 		--pid=container:$(CONTAINER_NAME) \
 		--net=container:$(CONTAINER_NAME) \
-		-v $(PWD):/out \
+		-v $(PWD):/out:z \
 		golang:alpine \
 		sh -c "go tool pprof -proto http://localhost:6060/debug/pprof/profile?seconds=$(PROFILE_TIME) > /out/cpu.pprof"
 	@echo "Profile captured to ./cpu.pprof, opening flamegraph..."

--- a/backend/internal/fft/convolve.go
+++ b/backend/internal/fft/convolve.go
@@ -13,14 +13,16 @@ func Convolve(f, g []complex128) []complex128 {
 	g = slices.Grow(g, n-len(g))
 	g = g[:n]
 
-	x := FFT(f)
-	y := FFT(g)
+	fftDIF(f)
+	fftDIF(g)
 
-	for i := range x {
-		x[i] *= y[i]
+	for i := range f {
+		f[i] *= g[i]
 	}
 
-	return IFFT(x)
+	ifftDIT(f)
+
+	return f
 }
 
 // Returns smallest power of 2 that is >= n.

--- a/backend/internal/fft/convolve.go
+++ b/backend/internal/fft/convolve.go
@@ -6,12 +6,12 @@ import (
 )
 
 func Convolve(f, g []complex128) []complex128 {
-	// Pad f and g to next power of 2
-	n := nextPow2(len(f) + len(g))
+	// Pad f and g to the next power of 2.
+	n := nextPow2(max(len(f), len(g)))
 	f = slices.Grow(f, n-len(f))
-	f = f[:cap(f)]
+	f = f[:n]
 	g = slices.Grow(g, n-len(g))
-	g = g[:cap(g)]
+	g = g[:n]
 
 	x := FFT(f)
 	y := FFT(g)

--- a/backend/internal/fft/fft.go
+++ b/backend/internal/fft/fft.go
@@ -4,15 +4,11 @@ import (
 	"math"
 	"math/bits"
 	"math/cmplx"
-	"slices"
 )
 
-func FFT(x []complex128) []complex128 {
-	n := nextPow2(len(x))
-	x = slices.Grow(x, n-len(x))
-	x = x[:cap(x)]
-
-	return fftIterative(x)
+// @param a Slice to perform FFT on. Length must be a power of two.
+func FFT(a []complex128) []complex128 {
+	return fftIterative(a)
 }
 
 func fftIterative(a []complex128) []complex128 {

--- a/backend/internal/fft/fft.go
+++ b/backend/internal/fft/fft.go
@@ -9,6 +9,29 @@ func FFT(x []complex128) []complex128 {
 	return fftRecursive(x, len(x), 1)
 }
 
+func fftIterative(a []complex128) []complex128 {
+	// do bit-reverse-copy of a
+
+	for s := 1; s <= int(math.Log2(float64(len(a)))); s++ {
+		m := 1 << s
+		exponent := complex(0, -2*math.Pi/float64(m))
+		omegaM := cmplx.Exp(exponent)
+
+		for k := 0; k < len(a); k += m {
+			omega := complex(1, 0)
+			for j := 0; j < m/2; j++ {
+				t := omega * a[k*j+m/2]
+				u := a[k+j]
+				a[k+j] = u + t
+				a[k+j+m/2] = u - t
+				omega *= omegaM
+			}
+		}
+	}
+
+	return a
+}
+
 // Simple implementation of the Cooley-Tukey radix-2 algorithm.
 // Recursively splits the DFT into two smaller smaller DFTs. O(nlogn) time complexity.
 // Possible optimization is removing explicit recursion.

--- a/backend/internal/fft/fft.go
+++ b/backend/internal/fft/fft.go
@@ -27,16 +27,17 @@ func fftDIF(a []complex128) {
 	for s := bits.Len(uint(len(a))) - 1; s >= 1; s-- {
 		m := 1 << s
 		stride := len(a) / m
+		half := m / 2
 
 		for k := 0; k < len(a); k += m {
-			for j := 0; j < m/2; j++ {
+			for j := range half {
 				twiddle := twiddles.forward[j*stride]
 
 				u := a[k+j]
-				v := a[k+j+m/2]
+				v := a[k+j+half]
 
 				a[k+j] = u + v
-				a[k+j+m/2] = (u - v) * twiddle
+				a[k+j+half] = (u - v) * twiddle
 			}
 		}
 	}
@@ -51,16 +52,17 @@ func ifftDIT(a []complex128) {
 	for s := 1; s < bits.Len(uint(len(a))); s++ {
 		m := 1 << s
 		stride := len(a) / m
+		half := m / 2
 
 		for k := 0; k < len(a); k += m {
-			for j := 0; j < m/2; j++ {
+			for j := range half {
 				twiddle := twiddles.inverse[j*stride]
 
-				t := twiddle * a[k+j+m/2]
+				t := twiddle * a[k+j+half]
 				u := a[k+j]
 
 				a[k+j] = u + t
-				a[k+j+m/2] = u - t
+				a[k+j+half] = u - t
 			}
 		}
 	}

--- a/backend/internal/fft/fft.go
+++ b/backend/internal/fft/fft.go
@@ -3,13 +3,17 @@ package fft
 import (
 	"math"
 	"math/bits"
+	"sync"
 )
 
-const MAXN = 1 << 16
+type twiddleTable struct {
+	forward []complex128
+	inverse []complex128
+}
 
 var (
-	forwardTwiddles = computeTwiddles(MAXN, false)
-	inverseTwiddles = computeTwiddles(MAXN, true)
+	cacheMu sync.RWMutex
+	cache   = make(map[int]twiddleTable)
 )
 
 // Iterative implementation of the Cooley-Tukey DIF algorithm.
@@ -18,13 +22,15 @@ var (
 // @param a The slice to perform FFT on. Length must be a power of 2.
 // Transform is done in-place and modifies this slice.
 func fftDIF(a []complex128) {
+	twiddles := getTwiddles(len(a))
+
 	for s := bits.Len(uint(len(a))) - 1; s >= 1; s-- {
 		m := 1 << s
-		stride := MAXN / m
+		stride := len(a) / m
 
 		for k := 0; k < len(a); k += m {
 			for j := 0; j < m/2; j++ {
-				twiddle := forwardTwiddles[j*stride]
+				twiddle := twiddles.forward[j*stride]
 
 				u := a[k+j]
 				v := a[k+j+m/2]
@@ -40,13 +46,15 @@ func fftDIF(a []complex128) {
 // @param a The slice to perform IFFT on. Length must be a power of 2.
 // Transform is done in-place and modifies this slice.
 func ifftDIT(a []complex128) {
+	twiddles := getTwiddles(len(a))
+
 	for s := 1; s < bits.Len(uint(len(a))); s++ {
 		m := 1 << s
-		stride := MAXN / m
+		stride := len(a) / m
 
 		for k := 0; k < len(a); k += m {
 			for j := 0; j < m/2; j++ {
-				twiddle := inverseTwiddles[j*stride]
+				twiddle := twiddles.inverse[j*stride]
 
 				t := twiddle * a[k+j+m/2]
 				u := a[k+j]
@@ -64,18 +72,32 @@ func ifftDIT(a []complex128) {
 	}
 }
 
-func computeTwiddles(n int, inverse bool) []complex128 {
-	twiddles := make([]complex128, n/2)
-	sign := -1.0
-	if inverse {
-		sign = 1.0
+func getTwiddles(n int) twiddleTable {
+	cacheMu.RLock()
+	table, ok := cache[n]
+	cacheMu.RUnlock()
+	if ok {
+		// Value is already stored in cache.
+		return table
 	}
 
+	// We need to compute it.
+	fwd := make([]complex128, n/2)
+	inv := make([]complex128, n/2)
 	for i := range n / 2 {
-		theta := sign * 2.0 * math.Pi * float64(i) / float64(n)
+		theta := 2.0 * math.Pi * float64(i) / float64(n)
 		s, c := math.Sincos(theta)
-		twiddles[i] = complex(c, s)
+		fwd[i] = complex(c, -s)
+		inv[i] = complex(c, s)
 	}
 
-	return twiddles
+	table = twiddleTable{forward: fwd, inverse: inv}
+
+	go func() {
+		cacheMu.Lock()
+		cache[n] = table
+		cacheMu.Unlock()
+	}()
+
+	return table
 }

--- a/backend/internal/fft/fft.go
+++ b/backend/internal/fft/fft.go
@@ -6,78 +6,55 @@ import (
 	"math/cmplx"
 )
 
-// @param a Slice to perform FFT on. Length must be a power of 2.
-func FFT(a []complex128) []complex128 {
-	return fftIterative(a)
-}
-
-// Iterative implementation of the Cooley-Tukey radix-2 algorithm.
+// Iterative implementation of the Cooley-Tukey DIF algorithm.
 // Based on the pseudocode here:
 // https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm#Data_reordering,_bit_reversal,_and_in-place_algorithms
 // @param a The slice to perform FFT on. Length must be a power of 2.
-func fftIterative(a []complex128) []complex128 {
-	bitReverseCopy(a)
-
-	for s := 1; s < bits.Len(uint(len(a))); s++ {
+// Transform is done in-place and modifies this slice.
+func fftDIF(a []complex128) {
+	for s := bits.Len(uint(len(a))) - 1; s >= 1; s-- {
 		m := 1 << s
-		exponent := complex(0, -2*math.Pi/float64(m))
-		omegaM := cmplx.Exp(exponent)
+		exp := cmplx.Exp(complex(0, -2*math.Pi/float64(m)))
 
 		for k := 0; k < len(a); k += m {
-			omega := complex(1, 0)
+			twiddle := complex(1, 0)
 			for j := 0; j < m/2; j++ {
-				t := omega * a[k+j+m/2]
 				u := a[k+j]
+				v := a[k+j+m/2]
+
+				a[k+j] = u + v
+				a[k+j+m/2] = (u - v) * twiddle
+
+				twiddle *= exp
+			}
+		}
+	}
+}
+
+// Iterative implementation of the Cooley-Tukey DIT algorithm.
+// @param a The slice to perform IFFT on. Length must be a power of 2.
+// Transform is done in-place and modifies this slice.
+func ifftDIT(a []complex128) {
+	for s := 1; s < bits.Len(uint(len(a))); s++ {
+		m := 1 << s
+		exp := cmplx.Exp(complex(0, 2*math.Pi/float64(m))) // Positive for inverse.
+
+		for k := 0; k < len(a); k += m {
+			twiddle := complex(1, 0)
+			for j := 0; j < m/2; j++ {
+				t := twiddle * a[k+j+m/2]
+				u := a[k+j]
+
 				a[k+j] = u + t
 				a[k+j+m/2] = u - t
-				omega *= omegaM
+				twiddle *= exp
 			}
 		}
 	}
 
-	return a
-}
-
-// Works because IFFT(x) = 1/n * FFT(timeReverse(x)),
-// where timeReverse is swapping elements symmetrically around the center excluding index 0.
-// Exploits DFT symmetry to compute IFFT using forward FFT.
-func IFFT(a []complex128) []complex128 {
-	n := len(a)
-	res := make([]complex128, n)
-	copy(res, a)
-
-	// Time reversal
-	for i := 1; i < n/2; i++ {
-		j := n - i
-		res[i], res[j] = res[j], res[i]
-	}
-
-	res = FFT(res)
-
-	// Scale output by 1/n
-	invN := complex(1.0/float64(n), 0)
-	for i := range res {
-		res[i] *= invN
-	}
-
-	return res
-}
-
-// @param a Slice to do bit reversal on. Length must be power of 2. Modified in place.
-func bitReverseCopy(a []complex128) {
-	n := len(a)
-	if n <= 2 {
-		return
-	}
-
-	leading := bits.LeadingZeros(uint(n - 1))
-
-	for i := range n {
-		// After reversing all the leading zeros will be on the right side.
-		// Therefore bitshift with that amount to keep it correctly inside the length of a.
-		r := int(bits.Reverse(uint(i)) >> uint(leading))
-		if i < r {
-			a[i], a[r] = a[r], a[i]
-		}
+	// Scale output by 1/n to return to original magnitude.
+	invN := complex(1.0/float64(len(a)), 0)
+	for i := range a {
+		a[i] *= invN
 	}
 }

--- a/backend/internal/fft/fft.go
+++ b/backend/internal/fft/fft.go
@@ -6,11 +6,15 @@ import (
 	"math/cmplx"
 )
 
-// @param a Slice to perform FFT on. Length must be a power of two.
+// @param a Slice to perform FFT on. Length must be a power of 2.
 func FFT(a []complex128) []complex128 {
 	return fftIterative(a)
 }
 
+// Iterative implementation of the Cooley-Tukey radix-2 algorithm.
+// Based on the pseudocode here:
+// https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm#Data_reordering,_bit_reversal,_and_in-place_algorithms
+// @param a The slice to perform FFT on. Length must be a power of 2.
 func fftIterative(a []complex128) []complex128 {
 	bitReverseCopy(a)
 
@@ -34,6 +38,31 @@ func fftIterative(a []complex128) []complex128 {
 	return a
 }
 
+// Works because IFFT(x) = 1/n * FFT(timeReverse(x)),
+// where timeReverse is swapping elements symmetrically around the center excluding index 0.
+// Exploits DFT symmetry to compute IFFT using forward FFT.
+func IFFT(a []complex128) []complex128 {
+	n := len(a)
+	res := make([]complex128, n)
+	copy(res, a)
+
+	// Time reversal
+	for i := 1; i < n/2; i++ {
+		j := n - i
+		res[i], res[j] = res[j], res[i]
+	}
+
+	res = FFT(res)
+
+	// Scale output by 1/n
+	invN := complex(1.0/float64(n), 0)
+	for i := range res {
+		res[i] *= invN
+	}
+
+	return res
+}
+
 // @param a Slice to do bit reversal on. Length must be power of 2. Modified in place.
 func bitReverseCopy(a []complex128) {
 	n := len(a)
@@ -51,59 +80,4 @@ func bitReverseCopy(a []complex128) {
 			a[i], a[r] = a[r], a[i]
 		}
 	}
-}
-
-// Simple implementation of the Cooley-Tukey radix-2 algorithm.
-// Recursively splits the DFT into two smaller smaller DFTs. O(nlogn) time complexity.
-// Possible optimization is removing explicit recursion.
-// @param a Slice of complex numbers to transform. Length must be power of 2.
-// @param n Current length of DFT to process. Must be power of 2.
-// @param s Current step. First compute even indices and the odd indices, then combines these.
-// This idea is extended recursively to give it the logarithmic time complexity.
-func fftRecursive(x []complex128, n, s int) []complex128 {
-	if n == 1 {
-		return []complex128{x[0]}
-	}
-
-	// Even and odd indices (only actually even and odd in first iteration/recursive call)
-	even := fftRecursive(x, n/2, 2*s)
-	odd := fftRecursive(x[s:], n/2, 2*s)
-
-	exp := cmplx.Rect(1, -2*math.Pi/float64(n)) // Roots of unity (please don't ask me to explain).
-	twiddle := complex(1, 0)                    // Twiddle factor, accumulates rotation.
-	res := make([]complex128, n)
-
-	for k := range n / 2 {
-		t := twiddle * odd[k]
-		res[k] = even[k] + t     // Set first half
-		res[k+n/2] = even[k] - t // Set second half
-
-		twiddle *= exp // twiddle becomes exp^1, exp^2, exp^3, etc.
-	}
-	return res
-}
-
-// Works because IFFT(x) = 1/n * FFT(timeReverse(x)),
-// where timeReverse is swapping elements symmetrically around the center excluding index 0.
-// Exploits DFT symmetry to compute IFFT using forward FFT.
-func IFFT(x []complex128) []complex128 {
-	n := len(x)
-	res := make([]complex128, n)
-	copy(res, x)
-
-	// Time reversal
-	for i := 1; i < n/2; i++ {
-		j := n - i
-		res[i], res[j] = res[j], res[i]
-	}
-
-	res = FFT(res)
-
-	// Scale output by 1/n
-	invN := complex(1.0/float64(n), 0)
-	for i := range res {
-		res[i] *= invN
-	}
-
-	return res
 }

--- a/backend/internal/fft/fft.go
+++ b/backend/internal/fft/fft.go
@@ -2,6 +2,7 @@ package fft
 
 import (
 	"math"
+	"math/bits"
 	"math/cmplx"
 )
 
@@ -10,7 +11,7 @@ func FFT(x []complex128) []complex128 {
 }
 
 func fftIterative(a []complex128) []complex128 {
-	// do bit-reverse-copy of a
+	bitReverseCopy(a)
 
 	for s := 1; s <= int(math.Log2(float64(len(a)))); s++ {
 		m := 1 << s
@@ -30,6 +31,25 @@ func fftIterative(a []complex128) []complex128 {
 	}
 
 	return a
+}
+
+// @param a Slice to do bit reversal on. Length must be power of 2. Modified in place.
+func bitReverseCopy(a []complex128) {
+	n := len(a)
+	if n <= 2 {
+		return
+	}
+
+	leading := bits.LeadingZeros(uint(n - 1))
+
+	for i := range n {
+		// After reversing all the leading zeros will be on the right side.
+		// Therefore bitshift with that amount to keep it correctly inside the length of a.
+		r := int(bits.Reverse(uint(i)) >> uint(leading))
+		if i < r {
+			a[i], a[r] = a[r], a[i]
+		}
+	}
 }
 
 // Simple implementation of the Cooley-Tukey radix-2 algorithm.

--- a/backend/internal/fft/fft.go
+++ b/backend/internal/fft/fft.go
@@ -3,7 +3,13 @@ package fft
 import (
 	"math"
 	"math/bits"
-	"math/cmplx"
+)
+
+const MAXN = 1 << 16
+
+var (
+	forwardTwiddles = computeTwiddles(MAXN, false)
+	inverseTwiddles = computeTwiddles(MAXN, true)
 )
 
 // Iterative implementation of the Cooley-Tukey DIF algorithm.
@@ -14,18 +20,17 @@ import (
 func fftDIF(a []complex128) {
 	for s := bits.Len(uint(len(a))) - 1; s >= 1; s-- {
 		m := 1 << s
-		exp := cmplx.Exp(complex(0, -2*math.Pi/float64(m)))
+		stride := MAXN / m
 
 		for k := 0; k < len(a); k += m {
-			twiddle := complex(1, 0)
 			for j := 0; j < m/2; j++ {
+				twiddle := forwardTwiddles[j*stride]
+
 				u := a[k+j]
 				v := a[k+j+m/2]
 
 				a[k+j] = u + v
 				a[k+j+m/2] = (u - v) * twiddle
-
-				twiddle *= exp
 			}
 		}
 	}
@@ -37,17 +42,17 @@ func fftDIF(a []complex128) {
 func ifftDIT(a []complex128) {
 	for s := 1; s < bits.Len(uint(len(a))); s++ {
 		m := 1 << s
-		exp := cmplx.Exp(complex(0, 2*math.Pi/float64(m))) // Positive for inverse.
+		stride := MAXN / m
 
 		for k := 0; k < len(a); k += m {
-			twiddle := complex(1, 0)
 			for j := 0; j < m/2; j++ {
+				twiddle := inverseTwiddles[j*stride]
+
 				t := twiddle * a[k+j+m/2]
 				u := a[k+j]
 
 				a[k+j] = u + t
 				a[k+j+m/2] = u - t
-				twiddle *= exp
 			}
 		}
 	}
@@ -57,4 +62,20 @@ func ifftDIT(a []complex128) {
 	for i := range a {
 		a[i] *= invN
 	}
+}
+
+func computeTwiddles(n int, inverse bool) []complex128 {
+	twiddles := make([]complex128, n/2)
+	sign := -1.0
+	if inverse {
+		sign = 1.0
+	}
+
+	for i := range n / 2 {
+		theta := sign * 2.0 * math.Pi * float64(i) / float64(n)
+		s, c := math.Sincos(theta)
+		twiddles[i] = complex(c, s)
+	}
+
+	return twiddles
 }

--- a/backend/internal/fft/fft.go
+++ b/backend/internal/fft/fft.go
@@ -4,10 +4,15 @@ import (
 	"math"
 	"math/bits"
 	"math/cmplx"
+	"slices"
 )
 
 func FFT(x []complex128) []complex128 {
-	return fftRecursive(x, len(x), 1)
+	n := nextPow2(len(x))
+	x = slices.Grow(x, n-len(x))
+	x = x[:cap(x)]
+
+	return fftIterative(x)
 }
 
 func fftIterative(a []complex128) []complex128 {
@@ -21,7 +26,7 @@ func fftIterative(a []complex128) []complex128 {
 		for k := 0; k < len(a); k += m {
 			omega := complex(1, 0)
 			for j := 0; j < m/2; j++ {
-				t := omega * a[k*j+m/2]
+				t := omega * a[k+j+m/2]
 				u := a[k+j]
 				a[k+j] = u + t
 				a[k+j+m/2] = u - t

--- a/backend/internal/fft/fft.go
+++ b/backend/internal/fft/fft.go
@@ -18,7 +18,7 @@ func FFT(x []complex128) []complex128 {
 func fftIterative(a []complex128) []complex128 {
 	bitReverseCopy(a)
 
-	for s := 1; s <= int(math.Log2(float64(len(a)))); s++ {
+	for s := 1; s < bits.Len(uint(len(a))); s++ {
 		m := 1 << s
 		exponent := complex(0, -2*math.Pi/float64(m))
 		omegaM := cmplx.Exp(exponent)


### PR DESCRIPTION
Closes #233 
Sped up the FFT calculations, and therefore the performance calculations, by 10 times (reducing from ~1.5s on a Mac Air M3 to ~150ms).
The main change is calculating the FFT iteratively instead of recursively.
We also exploit the fact that Decimation In Frequency takes "normal" ordering and outputs bit-reversed, while Decimation In Time takes bit-reverse order as input and outputs in normal ordering to avoid explicitly reversing anything.