### PR TITLE
fix: some contest results not stored

### DIFF
--- a/backend/cmd/fetcher/main.go
+++ b/backend/cmd/fetcher/main.go
@@ -120,6 +120,4 @@ func main() {
 			log.Printf("Successfully fetched and updated %d problems\n", count)
 		}
 	}
-
-	f.WG.Wait() // Wait until all DB updates finish.
 }

--- a/backend/cmd/fetcher/main.go
+++ b/backend/cmd/fetcher/main.go
@@ -48,6 +48,7 @@ func main() {
 		"Maximum allowed contests to update. Default is no maximum")
 	retryCount := flag.Int("retryCount", 5,
 		"How many times should we retry fetching a contest if it gives an error?")
+	contestIDToFetch := flag.Int("contestID", -1, "Fetch this specific contest. Used for debugging.")
 	flag.Parse()
 
 	if *fetchContests {
@@ -60,6 +61,11 @@ func main() {
 		if *maxContestUpdates != -1 && *maxContestUpdates < len(contestIDs) {
 			// Limit updates to maxContestUpdates.
 			contestIDs = contestIDs[:*maxContestUpdates]
+		}
+
+		if *contestIDToFetch != -1 {
+			contestIDs = contestIDs[:0]
+			contestIDs = append(contestIDs, *contestIDToFetch)
 		}
 
 		log.Printf("Starting fetching for %d contests\n", len(contestIDs))

--- a/backend/cmd/fetcher/main.go
+++ b/backend/cmd/fetcher/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	if *fetchContests {
 		log.Println("Finding unfetched contests")
-		contestIDs, err := f.FindContestsToUpdate(*maxContestsAge)
+		contestIDs, err := f.FindContestsToUpdate(context.Background(), *maxContestsAge)
 		if err != nil {
 			log.Fatalf("Failed to find contests to update: %v\n", err)
 		}
@@ -76,7 +76,7 @@ func main() {
 		i := 0
 		curFail := 0
 		for i < len(contestIDs) {
-			err := f.FetchContest(contestIDs[i])
+			err := f.FetchContest(context.Background(), contestIDs[i])
 			shouldContinue := true
 			if err != nil {
 				if errors.Is(err, codeforces.ErrRatingChangesUnavailable) {

--- a/backend/internal/codeforces/contest.go
+++ b/backend/internal/codeforces/contest.go
@@ -40,7 +40,7 @@ func (c *client) GetContestStandings(ctx context.Context, id int) ([]Contestant,
 	params := url.Values{}
 	params.Set("contestId", strconv.Itoa(id))
 	params.Set("from", "1")
-	params.Set("showUnofficial", "false")
+	params.Set("showUnofficial", "true")
 
 	resChan, err := c.makeRequest(ctx, endpoint+params.Encode())
 	if err != nil {
@@ -76,7 +76,9 @@ func (c *client) GetContestStandings(ctx context.Context, id int) ([]Contestant,
 		return nil, nil, fmt.Errorf("%w: %s", ErrCodeforcesReturnedFail, apiResp.Comment)
 	}
 
-	return apiResp.Result.Contestants, &apiResp.Result.Contest, nil
+	contestants := filterContestantsToOfficial(apiResp.Result.Contestants)
+
+	return contestants, &apiResp.Result.Contest, nil
 }
 
 func (c *client) GetContests(ctx context.Context) ([]Contest, error) {
@@ -112,7 +114,7 @@ func (c *client) GetContests(ctx context.Context) ([]Contest, error) {
 
 // Codeforces doesn't seem to return all official participants when "showUnofficial" is false.
 // This function is used to first get all contestants including unofficial ones, and then filter them.
-func FilterContestantsToOfficial(contestants []Contestant) []Contestant {
+func filterContestantsToOfficial(contestants []Contestant) []Contestant {
 	i, n := 0, len(contestants)
 	for i < n {
 		if contestants[i].Type != "CONTESTANT" {

--- a/backend/internal/codeforces/contest.go
+++ b/backend/internal/codeforces/contest.go
@@ -14,22 +14,23 @@ import (
 
 type Contestant struct {
 	Rank          int
-	Points        float64
+	ContestID     int
 	Penalty       int
-	ID            uint64
 	OldRating     int
 	NewRating     int
+	ID            uint64
+	Points        float64
+	Type          string
 	MemberHandles []string
-	ContestID     int
 }
 
 type Contest struct {
 	ID        int       `json:"id"`
-	Name      string    `json:"name"`
-	StartTime time.Time `json:"startTime"`
-	Duration  int       `json:"durationSeconds"`
-	Phase     string    `json:"phase"`
 	Div       int       `db:"div"`
+	Duration  int       `json:"durationSeconds"`
+	StartTime time.Time `json:"startTime"`
+	Name      string    `json:"name"`
+	Phase     string    `json:"phase"`
 }
 
 var ErrNoStandings = errors.New("could not find standings")
@@ -109,14 +110,35 @@ func (c *client) GetContests(ctx context.Context) ([]Contest, error) {
 	return apiResp.Result, nil
 }
 
+// Codeforces doesn't seem to return all official participants when "showUnofficial" is false.
+// This function is used to first get all contestants including unofficial ones, and then filter them.
+func FilterContestantsToOfficial(contestants []Contestant) []Contestant {
+	i, n := 0, len(contestants)
+	for i < n {
+		if contestants[i].Type != "CONTESTANT" {
+			// Contestant is not official, swap to back
+			contestants[i], contestants[n-1] = contestants[n-1], contestants[i]
+			n--
+			continue
+		}
+
+		i++
+	}
+
+	contestants = contestants[:n]
+
+	return contestants
+}
+
 func (c *Contestant) UnmarshalJSON(data []byte) error {
 	type rawContestant struct {
 		Rank    int     `json:"rank"`
 		Points  float64 `json:"points"`
 		Penalty int     `json:"penalty"`
 		Party   struct {
-			ParticipantID uint64 `json:"participantId"`
-			Members       []struct {
+			ParticipantID   uint64 `json:"participantId"`
+			ParticipantType string `json:"participantType"`
+			Members         []struct {
 				Handle string `json:"handle"`
 			} `json:"members"`
 		} `json:"party"`
@@ -131,6 +153,7 @@ func (c *Contestant) UnmarshalJSON(data []byte) error {
 	c.Points = raw.Points
 	c.Penalty = raw.Penalty
 	c.ID = raw.Party.ParticipantID
+	c.Type = raw.Party.ParticipantType
 
 	for _, member := range raw.Party.Members {
 		c.MemberHandles = append(c.MemberHandles, member.Handle)

--- a/backend/internal/db/contest_results.go
+++ b/backend/internal/db/contest_results.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	ErrContestNotStored    = errors.New("did not find contest in db")
-	ErrNoResultsWithHandle = errors.New("did not find contest results with provided handle")
+	ErrContestNotStored        = errors.New("did not find contest in db")
+	ErrNoResultsWithHandle     = errors.New("did not find contest results with provided handle")
+	ErrContestantMissingHandle = errors.New("a contestant did not have any associated handles")
 )
 
 func (db *db) InsertContestResults(ctx context.Context, contestants []codeforces.Contestant, id int) error {
@@ -24,6 +25,10 @@ func (db *db) InsertContestResultsTx(ctx context.Context, q Querier,
 
 	batch := &pgx.Batch{}
 	for _, c := range contestants {
+		if len(c.MemberHandles) == 0 {
+			return ErrContestantMissingHandle
+		}
+
 		for i := range c.MemberHandles {
 			c.MemberHandles[i] = strings.ToLower(c.MemberHandles[i])
 		}

--- a/backend/internal/fetcher/contest.go
+++ b/backend/internal/fetcher/contest.go
@@ -11,17 +11,17 @@ import (
 	"github.com/yuqzii/codeforces-insights/internal/db"
 )
 
-func (f *fetcher) FetchContest(id int) error {
-	contestants, contest, err := f.contestProvider.GetContestStandings(context.TODO(), id)
+func (f *fetcher) FetchContest(ctx context.Context, id int) error {
+	contestants, contest, err := f.contestProvider.GetContestStandings(ctx, id)
 	if err != nil {
 		return fmt.Errorf("getting contest standings: %w", err)
 	}
 
-	ratings, err := f.contestProvider.GetContestRatingChanges(context.TODO(), id)
+	ratings, err := f.contestProvider.GetContestRatingChanges(ctx, id)
 	if err != nil {
 		if errors.Is(err, codeforces.ErrRatingChangesUnavailable) {
 			// Insert to avoid refetch, usually means the contest was unrated.
-			_, err = f.contestRepo.UpsertContest(context.TODO(), contest)
+			_, err = f.contestRepo.UpsertContest(ctx, contest)
 			return err
 		}
 		return fmt.Errorf("getting contest ratings: %w", err)
@@ -43,7 +43,7 @@ func (f *fetcher) FetchContest(id int) error {
 			// Only insert the contest, no contestants as they don't have any rating info.
 			// This is to avoid calling the Codeforces API many times for the same contest,
 			// when we could just store it to indicate that we already have all available data.
-			_, err = f.contestRepo.UpsertContest(context.TODO(), contest)
+			_, err = f.contestRepo.UpsertContest(ctx, contest)
 			return err
 		}
 
@@ -62,15 +62,15 @@ func (f *fetcher) FetchContest(id int) error {
 		}
 	}
 
-	f.insertContestDB(context.TODO(), contest, contestants)
+	f.insertContestDB(ctx, contest, contestants)
 
 	return nil
 }
 
 // @param maxAge The maximum age allowed before the data is considered stale.
 // @return Slice of the IDs of all contests needing to be updated. (Either stale or not previously fetched).
-func (f *fetcher) FindContestsToUpdate(maxAge time.Duration) ([]int, error) {
-	c, err := f.contestProvider.GetContests(context.TODO())
+func (f *fetcher) FindContestsToUpdate(ctx context.Context, maxAge time.Duration) ([]int, error) {
+	c, err := f.contestProvider.GetContests(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting contests: %w", err)
 	}
@@ -82,7 +82,7 @@ func (f *fetcher) FindContestsToUpdate(maxAge time.Duration) ([]int, error) {
 		}
 	}
 
-	existing, err := f.contestRepo.ContestsExists(context.TODO(), finished)
+	existing, err := f.contestRepo.ContestsExists(ctx, finished)
 	if err != nil {
 		return nil, fmt.Errorf("checking contests existence: %w", err)
 	}
@@ -95,7 +95,7 @@ func (f *fetcher) FindContestsToUpdate(maxAge time.Duration) ([]int, error) {
 		}
 	}
 
-	stale, err := f.contestRepo.FindStaleContests(context.TODO(), maxAge)
+	stale, err := f.contestRepo.FindStaleContests(ctx, maxAge)
 	if err != nil {
 		return nil, fmt.Errorf("finding stale contests: %w", err)
 	}

--- a/backend/internal/fetcher/contest.go
+++ b/backend/internal/fetcher/contest.go
@@ -20,8 +20,8 @@ func (f *fetcher) FetchContest(id int) error {
 	ratings, err := f.contestProvider.GetContestRatingChanges(context.TODO(), id)
 	if err != nil {
 		if errors.Is(err, codeforces.ErrRatingChangesUnavailable) {
-			// Insert to avoid refetch.
-			f.insertContestDB(context.TODO(), contest, contestants)
+			// Insert to avoid refetch, usually means the contest was unrated.
+			_, err = f.contestRepo.UpsertContest(context.TODO(), contest)
 			return err
 		}
 		return fmt.Errorf("getting contest ratings: %w", err)
@@ -43,7 +43,6 @@ func (f *fetcher) FetchContest(id int) error {
 			// Only insert the contest, no contestants as they don't have any rating info.
 			// This is to avoid calling the Codeforces API many times for the same contest,
 			// when we could just store it to indicate that we already have all available data.
-			log.Println("is old")
 			_, err = f.contestRepo.UpsertContest(context.TODO(), contest)
 			return err
 		}

--- a/backend/internal/fetcher/contest.go
+++ b/backend/internal/fetcher/contest.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/yuqzii/codeforces-insights/internal/codeforces"
@@ -62,9 +61,7 @@ func (f *fetcher) FetchContest(ctx context.Context, id int) error {
 		}
 	}
 
-	f.insertContestDB(ctx, contest, contestants)
-
-	return nil
+	return f.insertContestDB(ctx, contest, contestants)
 }
 
 // @param maxAge The maximum age allowed before the data is considered stale.
@@ -107,7 +104,7 @@ func (f *fetcher) FindContestsToUpdate(ctx context.Context, maxAge time.Duration
 // Upserts the provided contest and contestants.
 // Uses a gouroutine to avoid blocking while waiting for the DB update.
 func (f *fetcher) insertContestDB(ctx context.Context, contest *codeforces.Contest,
-	contestants []codeforces.Contestant) {
+	contestants []codeforces.Contestant) error {
 
 	err := f.tx.WithTx(ctx, func(q db.Querier) error {
 		id, err := f.contestRepo.UpsertContestTx(ctx, q, contest)
@@ -124,8 +121,8 @@ func (f *fetcher) insertContestDB(ctx context.Context, contest *codeforces.Conte
 	})
 
 	if err != nil {
-		log.Printf("Error when updating db during contest fetch (id %d): %v\n", contest.ID, err)
-	} else {
-		log.Printf("Successfully updated contest %d\n", contest.ID)
+		return fmt.Errorf("updating db during contest fetch (id %d): %w", contest.ID, err)
 	}
+
+	return nil
 }

--- a/backend/internal/fetcher/contest.go
+++ b/backend/internal/fetcher/contest.go
@@ -21,7 +21,7 @@ func (f *fetcher) FetchContest(id int) error {
 	if err != nil {
 		if errors.Is(err, codeforces.ErrRatingChangesUnavailable) {
 			// Insert to avoid refetch.
-			f.insertContestDB(context.Background(), contest, nil)
+			f.insertContestDB(context.TODO(), contest, contestants)
 			return err
 		}
 		return fmt.Errorf("getting contest ratings: %w", err)
@@ -43,6 +43,7 @@ func (f *fetcher) FetchContest(id int) error {
 			// Only insert the contest, no contestants as they don't have any rating info.
 			// This is to avoid calling the Codeforces API many times for the same contest,
 			// when we could just store it to indicate that we already have all available data.
+			log.Println("is old")
 			_, err = f.contestRepo.UpsertContest(context.TODO(), contest)
 			return err
 		}
@@ -109,25 +110,23 @@ func (f *fetcher) FindContestsToUpdate(maxAge time.Duration) ([]int, error) {
 func (f *fetcher) insertContestDB(ctx context.Context, contest *codeforces.Contest,
 	contestants []codeforces.Contestant) {
 
-	f.WG.Go(func() {
-		err := f.tx.WithTx(ctx, func(q db.Querier) error {
-			id, err := f.contestRepo.UpsertContestTx(ctx, q, contest)
-			if err != nil {
-				return fmt.Errorf("upserting contest %d: %w", id, err)
-			}
-
-			err = f.contestRepo.InsertContestResultsTx(ctx, q, contestants, id)
-			if err != nil {
-				return fmt.Errorf("inserting contest %d results: %w", id, err)
-			}
-
-			return nil
-		})
-
+	err := f.tx.WithTx(ctx, func(q db.Querier) error {
+		id, err := f.contestRepo.UpsertContestTx(ctx, q, contest)
 		if err != nil {
-			log.Printf("Error when updating db during contest fetch (id %d): %v\n", contest.ID, err)
-		} else {
-			log.Printf("Successfully updated contest %d\n", contest.ID)
+			return fmt.Errorf("upserting contest %d: %w", id, err)
 		}
+
+		err = f.contestRepo.InsertContestResultsTx(ctx, q, contestants, id)
+		if err != nil {
+			return fmt.Errorf("inserting contest %d results: %w", id, err)
+		}
+
+		return nil
 	})
+
+	if err != nil {
+		log.Printf("Error when updating db during contest fetch (id %d): %v\n", contest.ID, err)
+	} else {
+		log.Printf("Successfully updated contest %d\n", contest.ID)
+	}
 }

--- a/backend/internal/fetcher/fetcher.go
+++ b/backend/internal/fetcher/fetcher.go
@@ -3,7 +3,6 @@ package fetcher
 import (
 	"context"
 	"errors"
-	"sync"
 	"time"
 
 	"github.com/yuqzii/codeforces-insights/internal/codeforces"
@@ -18,8 +17,6 @@ type fetcher struct {
 	problemProvider ProblemProvider
 	problemRepo     ProblemRepository
 	tx              db.TxManager
-
-	WG sync.WaitGroup
 }
 
 type ContestProvider interface {

--- a/backend/migrations/0010_add_not_empty_handle_constraint.down.sql
+++ b/backend/migrations/0010_add_not_empty_handle_constraint.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE contest_result_handles
+DROP CONSTRAINT IF EXISTS not_empty_handle;

--- a/backend/migrations/0010_add_not_empty_handle_constraint.up.sql
+++ b/backend/migrations/0010_add_not_empty_handle_constraint.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE contest_result_handles
+ADD CONSTRAINT not_empty_handle
+CHECK (handle <> '');


### PR DESCRIPTION
### Problem
for at least the first few contests a user participates in they are not
included in the "official" list from the API. However, their rank given
from the api with `showUnoffical=true` is the correct one as opposed to
the one received from the rating change endpoint.

### Solution
Get the complete list including unoffical participants, and then filter
to only the official participants (the ones with type as "CONTESTANT").

## Other changes
- Added a `contestID` debug flag to the fetcher to allow fetching of a single specific contest.
- Added a constraint to the DB preventing the `handle` column in the results from being empty (`''`, but not `NULL` which was already constrained).
- Made the `insertContestDB` function not start a goroutine, as this lead to some weird bugs on edge cases without really speeding up as the rate limit is the main bottleneck anyways.