### PR TITLE
fix: recommending already solved problems

### DIFF
--- a/backend/internal/db/problems.go
+++ b/backend/internal/db/problems.go
@@ -202,6 +202,7 @@ func correctProblemIndices(probsDiv []probWithDiv, probs map[int][]codeforces.Pr
 	[]probWithDiv, map[int][]codeforces.Problem, error) {
 
 	var increment uint8 = 0
+	contestIDs := make(map[int]struct{})
 
 	for i, p := range probsDiv {
 		newProb := p.Problem
@@ -219,7 +220,11 @@ func correctProblemIndices(probsDiv []probWithDiv, probs map[int][]codeforces.Pr
 			}
 		}
 
-		probs[probsDiv[0].ContestID] = append(probs[probsDiv[0].ContestID], newProb)
+		contestIDs[p.ContestID] = struct{}{}
+		// Add problem to all contests it was part of.
+		for id := range contestIDs {
+			probs[id] = append(probs[probsDiv[0].ContestID], newProb)
+		}
 	}
 
 	probsDiv = probsDiv[:0]

--- a/backend/internal/db/problems.go
+++ b/backend/internal/db/problems.go
@@ -53,6 +53,7 @@ func (db *db) GetProblemsWithTagsTx(ctx context.Context, q Querier, tags []strin
 }
 
 // @param id External Codeforces ID of the contest.
+// @return List of problems beloning to the specified contest in ascending order of index.
 func (db *db) GetProblemsFromContest(ctx context.Context, id int) ([]codeforces.Problem, error) {
 	return db.GetProblemsFromContestTx(ctx, db.q, id)
 }

--- a/backend/internal/db/problems.go
+++ b/backend/internal/db/problems.go
@@ -114,7 +114,7 @@ func (db *db) GetProblemsFromContestsTx(ctx context.Context, q Querier, ids []in
 		probsDiv = append(probsDiv, prob)
 	}
 
-	probsDiv, problems, err = correctProblemIndices(probsDiv, problems)
+	_, problems, err = correctProblemIndices(probsDiv, problems)
 	if err != nil {
 		return nil, fmt.Errorf("correcting problem indices: %w", err)
 	}

--- a/backend/internal/db/problems.go
+++ b/backend/internal/db/problems.go
@@ -197,7 +197,7 @@ type probWithDiv struct {
 
 // Converts []probWithDiv to []codeforces.Problem and updates their indices,
 // in case of multiple contests sharing problems.
-// @param probs Slice of probWithDiv, must be sorted by div descending, and then by index ascending.
+// @param probsDiv Slice of probWithDiv, must be sorted by div descending, and then by index ascending.
 func correctProblemIndices(probsDiv []probWithDiv, probs map[int][]codeforces.Problem) (
 	[]probWithDiv, map[int][]codeforces.Problem, error) {
 

--- a/backend/internal/db/problems.go
+++ b/backend/internal/db/problems.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/yuqzii/codeforces-insights/internal/codeforces"
 )
 
-var ErrNoProblemsForContest = errors.New("there are no stored problems for this contest")
+var ErrNoProblemsForContests = errors.New("there are no stored problems for these contests")
 var ErrTooManyProblems = errors.New("amount of problems exceeds alphabet")
 
 func (db *db) GetProblemsWithTags(ctx context.Context, tags []string, minRat, maxRat int) (
@@ -53,17 +54,19 @@ func (db *db) GetProblemsWithTagsTx(ctx context.Context, q Querier, tags []strin
 }
 
 // @param id External Codeforces ID of the contest.
-// @return List of problems beloning to the specified contest in ascending order of index.
-func (db *db) GetProblemsFromContest(ctx context.Context, id int) ([]codeforces.Problem, error) {
-	return db.GetProblemsFromContestTx(ctx, db.q, id)
+// @return Map of problems slices belonging to the specified contests in ascending order of index.
+func (db *db) GetProblemsFromContests(ctx context.Context, ids []int) (map[int][]codeforces.Problem, error) {
+	return db.GetProblemsFromContestsTx(ctx, db.q, ids)
 }
 
-func (db *db) GetProblemsFromContestTx(ctx context.Context, q Querier, id int) ([]codeforces.Problem, error) {
+func (db *db) GetProblemsFromContestsTx(ctx context.Context, q Querier, ids []int) (
+	map[int][]codeforces.Problem, error) {
+
 	rows, err := q.Query(ctx, `
 		WITH reference_contest AS (
 			SELECT COALESCE(div, 0) AS div, start_time, contest_id
 			FROM contests
-			WHERE contest_id = $1
+			WHERE contest_id = ANY($1)
 		)
 		SELECT
 			p.name,
@@ -71,30 +74,60 @@ func (db *db) GetProblemsFromContestTx(ctx context.Context, q Querier, id int) (
 			COALESCE(p.rating, 0) AS rating,
 			p.tags,
 			c.contest_id,
-			COALESCE(c.div, 0) AS div
+			COALESCE(c.div, 0) AS div,
+			c.start_time
 		FROM problems p
 		JOIN contests c ON p.contest_id = c.id
 		CROSS JOIN reference_contest rc
 		WHERE
 			c.start_time = rc.start_time AND
 			COALESCE(c.div, 0) <= rc.div
-		ORDER BY COALESCE(c.div, 0) DESC, p.index ASC`,
-		id,
+		ORDER BY c.start_time ASC, COALESCE(c.div, 0) DESC, p.index ASC`,
+		ids,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("querying problems: %w", err)
 	}
 
-	problems, err := pgx.CollectRows(rows, pgx.RowToStructByName[probWithDiv])
+	// Problems from contests sharing problems are grouped together in probsDiv.
+	// When a new "group" starts the indices are corrected and problems are pushed into the problems slice,
+	// and probsDiv is cleared.
+	probsDiv := make([]probWithDiv, 0)
+	problems := make(map[int][]codeforces.Problem, 0)
+	for rows.Next() {
+		var prob probWithDiv
+		err := rows.Scan(&prob.Name, &prob.Index, &prob.Rating, &prob.Tags,
+			&prob.ContestID, &prob.Div, &prob.StartTime,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scanning row into problem: %w", err)
+		}
+
+		n := len(probsDiv)
+		if n > 0 && !probsDiv[n-1].StartTime.Equal(prob.StartTime) {
+			probsDiv, problems, err = correctProblemIndices(probsDiv, problems)
+			if err != nil {
+				return nil, fmt.Errorf("correcting problem indices: %w", err)
+			}
+		}
+
+		probsDiv = append(probsDiv, prob)
+	}
+
+	probsDiv, problems, err = correctProblemIndices(probsDiv, problems)
 	if err != nil {
-		return nil, fmt.Errorf("collecting rows: %w", err)
+		return nil, fmt.Errorf("correcting problem indices: %w", err)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading rows: %w", err)
 	}
 
 	if len(problems) == 0 {
-		return nil, ErrNoProblemsForContest
+		return nil, ErrNoProblemsForContests
 	}
 
-	return correctProblemIndices(problems)
+	return problems, nil
 }
 
 func (db *db) UpsertProblem(ctx context.Context, p *codeforces.Problem) error {
@@ -158,36 +191,40 @@ func (db *db) UpsertProblemsBatchTx(ctx context.Context, q Querier, probs []code
 
 type probWithDiv struct {
 	codeforces.Problem
-	Div int `db:"div"`
+	Div       int       `db:"div"`
+	StartTime time.Time `db:"start_time"`
 }
 
 // Converts []probWithDiv to []codeforces.Problem and updates their indices,
 // in case of multiple contests sharing problems.
 // @param probs Slice of probWithDiv, must be sorted by div descending, and then by index ascending.
-func correctProblemIndices(probs []probWithDiv) ([]codeforces.Problem, error) {
-	res := make([]codeforces.Problem, 0, len(probs))
+func correctProblemIndices(probsDiv []probWithDiv, probs map[int][]codeforces.Problem) (
+	[]probWithDiv, map[int][]codeforces.Problem, error) {
+
 	var increment uint8 = 0
 
-	for i, p := range probs {
+	for i, p := range probsDiv {
 		newProb := p.Problem
 		newProb.Index = strings.TrimSpace(newProb.Index)
 
 		if err := updateIndex(&newProb, increment); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		if i < len(probs)-1 && probs[i+1].Div < p.Div {
+		if i < len(probsDiv)-1 && probsDiv[i+1].Div < p.Div {
 			// Next problem is from a new contest, update increment.
 			increment = newProb.Index[0] - 'A' + 1
 			if increment >= 26 {
-				return nil, ErrTooManyProblems
+				return nil, nil, ErrTooManyProblems
 			}
 		}
 
-		res = append(res, newProb)
+		probs[probsDiv[0].ContestID] = append(probs[probsDiv[0].ContestID], newProb)
 	}
 
-	return res, nil
+	probsDiv = probsDiv[:0]
+
+	return probsDiv, probs, nil
 }
 
 func updateIndex(p *codeforces.Problem, increment uint8) error {

--- a/backend/internal/db/problems_test.go
+++ b/backend/internal/db/problems_test.go
@@ -68,11 +68,14 @@ func TestCorrectProblemIndices(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := correctProblemIndices(test.input)
+			mp := make(map[int][]codeforces.Problem)
+			_, got, err := correctProblemIndices(test.input, mp)
 			require.Nil(t, err)
 
-			for i, p := range got {
-				assert.Equal(t, test.wants[i], p.Index, "problem %d has wrong index", i)
+			for _, probs := range got {
+				for i, p := range probs {
+					assert.Equal(t, test.wants[i], p.Index, "problem %d has wrong index", i)
+				}
 			}
 		})
 	}

--- a/backend/internal/handlers/recommend.go
+++ b/backend/internal/handlers/recommend.go
@@ -19,6 +19,7 @@ type RecommendationProvider interface {
 	FindUnsolvedProblems(ctx context.Context, solvedByContest map[int][]*codeforces.Problem) (
 		[]*codeforces.Problem, error)
 	FindSolvedRecentContests(subs []codeforces.Submission, lookback int) map[int][]*codeforces.Problem
+	GetSolvedProblemHashes(ctx context.Context, probs []*codeforces.Problem) ([]int64, error)
 }
 
 type recommendReq struct {
@@ -92,9 +93,19 @@ func (h *Handler) HandleRecommend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Collect all already solved problems into a set.
+	allSolvedProbs := make([]*codeforces.Problem, len(data.AcceptedSubs))
+	for i := range data.AcceptedSubs {
+		allSolvedProbs[i] = &data.AcceptedSubs[i].Problem
+	}
+	solvedHashes, err := h.rec.GetSolvedProblemHashes(ctx, allSolvedProbs)
+	if err != nil {
+		http.Error(w, "Failure hashing solved problems", http.StatusInternalServerError)
+		log.Printf("Error hashing solved problems: %v\n", err)
+		return
+	}
+
 	disallowedProbs := make(map[int64]struct{})
-	for _, sub := range data.AcceptedSubs {
-		hash := sub.Problem.Hash()
+	for _, hash := range solvedHashes {
 		disallowedProbs[hash] = struct{}{}
 	}
 

--- a/backend/internal/recommender/recommender.go
+++ b/backend/internal/recommender/recommender.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 
@@ -166,6 +167,33 @@ func (r *recommender) FindSolvedRecentContests(subs []codeforces.Submission,
 	}
 
 	return probsByContest
+}
+
+func (r *recommender) GetSolvedProblemHashes(ctx context.Context, probs []*codeforces.Problem) ([]int64, error) {
+	probsByContest := make(map[int][]codeforces.Problem)
+	hashes := make([]int64, len(probs))
+
+	for i, p := range probs {
+		contestProbs, ok := probsByContest[p.ContestID]
+		if !ok {
+			var err error
+			contestProbs, err = r.probRepo.GetProblemsFromContest(ctx, p.ContestID)
+			if err != nil {
+				return nil, fmt.Errorf("getting problems from contest %d: %w", p.ContestID, err)
+			}
+
+			probsByContest[p.ContestID] = contestProbs
+		}
+
+		j := sort.Search(len(contestProbs), func(i int) bool {
+			return contestProbs[i].Index >= p.Index
+		})
+
+		actualProb := contestProbs[j]
+		hashes[i] = actualProb.Hash()
+	}
+
+	return hashes, nil
 }
 
 // _𜰾𜰱‾ used as a scalar by contestID such that newer problems gets recommended more

--- a/backend/internal/recommender/recommender.go
+++ b/backend/internal/recommender/recommender.go
@@ -17,7 +17,7 @@ import (
 )
 
 type ProblemRepository interface {
-	GetProblemsFromContest(ctx context.Context, id int) ([]codeforces.Problem, error)
+	GetProblemsFromContests(ctx context.Context, ids []int) (map[int][]codeforces.Problem, error)
 	// Should return all problems matching at least one tag.
 	GetProblemsWithTags(ctx context.Context, tags []string, minRat, maxRat int) (
 		[]codeforces.Problem, error)
@@ -117,7 +117,7 @@ func (r *recommender) FindUnsolvedProblems(ctx context.Context,
 				continue
 			}
 
-			if errors.Is(err, db.ErrNoProblemsForContest) {
+			if errors.Is(err, db.ErrNoProblemsForContests) {
 				log.Printf("Couldn't find problems from contest %d: %v\n", contestID, err)
 				continue
 			}
@@ -176,8 +176,8 @@ func (r *recommender) GetSolvedProblemHashes(ctx context.Context, probs []*codef
 	for i, p := range probs {
 		contestProbs, ok := probsByContest[p.ContestID]
 		if !ok {
-			var err error
-			contestProbs, err = r.probRepo.GetProblemsFromContest(ctx, p.ContestID)
+			probMap, err := r.probRepo.GetProblemsFromContests(ctx, []int{p.ContestID})
+			contestProbs = probMap[p.ContestID]
 			if err != nil {
 				return nil, fmt.Errorf("getting problems from contest %d: %w", p.ContestID, err)
 			}
@@ -209,10 +209,11 @@ func sigmoid(x float64) float64 {
 func (r *recommender) findFirstUnsolvedProblem(ctx context.Context, contestID int,
 	indices []string) (*codeforces.Problem, error) {
 
-	allProbs, err := r.probRepo.GetProblemsFromContest(ctx, contestID)
+	probMap, err := r.probRepo.GetProblemsFromContests(ctx, []int{contestID})
 	if err != nil {
 		return nil, fmt.Errorf("getting problems to contest %d: %w", contestID, err)
 	}
+	allProbs := probMap[contestID]
 
 	if len(indices) > len(allProbs) {
 		return nil, ErrInvalidIndices

--- a/backend/internal/recommender/recommender.go
+++ b/backend/internal/recommender/recommender.go
@@ -38,9 +38,8 @@ func New(repo ProblemRepository) *recommender {
 }
 
 var (
-	ErrNoUnsolvedProblem   = errors.New("there are no unsolved problems for this contest")
-	ErrInvalidIndices      = errors.New("given problem indices are invalid")
-	ErrNoProblemsInContest = errors.New("no problems returned for this contest")
+	ErrNoUnsolvedProblem = errors.New("there are no unsolved problems for this contest")
+	ErrInvalidIndices    = errors.New("given problem indices are invalid")
 )
 
 // Converts all the problems tags into a vector, and compares the direction of this vector
@@ -186,7 +185,10 @@ func (r *recommender) GetSolvedProblemHashes(ctx context.Context, probs []*codef
 	for i, p := range probs {
 		actualProbs, ok := probsByContest[p.ContestID]
 		if !ok {
-			return nil, fmt.Errorf("accessing contest %d problems: %w", p.ContestID, ErrNoProblemsInContest)
+			// A solved problem is not stored in DB, could mean the problem is from a gym.
+			// Should be fine to ignore, as any valid problem for recommendation should have been
+			// returned anyways.
+			continue
 		}
 
 		// Find actual problem index.

--- a/backend/internal/recommender/recommender.go
+++ b/backend/internal/recommender/recommender.go
@@ -38,8 +38,9 @@ func New(repo ProblemRepository) *recommender {
 }
 
 var (
-	ErrNoUnsolvedProblem = errors.New("there are no unsolved problems for this contest")
-	ErrInvalidIndices    = errors.New("given problem indices are invalid")
+	ErrNoUnsolvedProblem   = errors.New("there are no unsolved problems for this contest")
+	ErrInvalidIndices      = errors.New("given problem indices are invalid")
+	ErrNoProblemsInContest = errors.New("no problems returned for this contest")
 )
 
 // Converts all the problems tags into a vector, and compares the direction of this vector
@@ -170,26 +171,30 @@ func (r *recommender) FindSolvedRecentContests(subs []codeforces.Submission,
 }
 
 func (r *recommender) GetSolvedProblemHashes(ctx context.Context, probs []*codeforces.Problem) ([]int64, error) {
-	probsByContest := make(map[int][]codeforces.Problem)
+	contestIDs := make([]int, 0)
+	for _, p := range probs {
+		contestIDs = append(contestIDs, p.ContestID)
+	}
+
+	probsByContest, err := r.probRepo.GetProblemsFromContests(ctx, contestIDs)
+	if err != nil {
+		return nil, fmt.Errorf("getting problems from contests %v: %w", contestIDs, err)
+	}
+
 	hashes := make([]int64, len(probs))
 
 	for i, p := range probs {
-		contestProbs, ok := probsByContest[p.ContestID]
+		actualProbs, ok := probsByContest[p.ContestID]
 		if !ok {
-			probMap, err := r.probRepo.GetProblemsFromContests(ctx, []int{p.ContestID})
-			contestProbs = probMap[p.ContestID]
-			if err != nil {
-				return nil, fmt.Errorf("getting problems from contest %d: %w", p.ContestID, err)
-			}
-
-			probsByContest[p.ContestID] = contestProbs
+			return nil, fmt.Errorf("accessing contest %d problems: %w", p.ContestID, ErrNoProblemsInContest)
 		}
 
-		j := sort.Search(len(contestProbs), func(i int) bool {
-			return contestProbs[i].Index >= p.Index
+		// Find actual problem index.
+		j := sort.Search(len(actualProbs), func(i int) bool {
+			return actualProbs[i].Index >= p.Index
 		})
 
-		actualProb := contestProbs[j]
+		actualProb := actualProbs[j]
 		hashes[i] = actualProb.Hash()
 	}
 

--- a/backend/internal/recommender/recommender_test.go
+++ b/backend/internal/recommender/recommender_test.go
@@ -14,11 +14,11 @@ type mockProblemRepository struct {
 	mock.Mock
 }
 
-func (m *mockProblemRepository) GetProblemsFromContest(ctx context.Context, id int) (
-	[]codeforces.Problem, error) {
+func (m *mockProblemRepository) GetProblemsFromContests(ctx context.Context, ids []int) (
+	map[int][]codeforces.Problem, error) {
 
-	args := m.Called(id)
-	return args.Get(0).([]codeforces.Problem), args.Error(1)
+	args := m.Called(ids)
+	return args.Get(0).(map[int][]codeforces.Problem), args.Error(1)
 }
 
 func (m *mockProblemRepository) GetProblemsWithTags(ctx context.Context, tags []string, minRat, maxRat int) (
@@ -113,23 +113,25 @@ func TestFindFirstUnsolvedProblem(t *testing.T) {
 			Tags:      []string{"dp", "brute force"},
 		}
 
-		mockCall := m.On("GetProblemsFromContest", 1).Return([]codeforces.Problem{
-			{
-				Name:      "Impossible Problem",
-				ContestID: 1,
-				Index:     "D",
-				Tags:      []string{"dp", "brute force"},
-			}, {
-				Name:      "More Possible Problem",
-				ContestID: 1,
-				Index:     "B",
-				Tags:      []string{"dp", "brute force"},
-			}, {
-				Name:      "Super Easy Problem",
-				ContestID: 1,
-				Index:     "A",
-				Tags:      []string{"dp", "brute force"},
-			}, expected,
+		mockCall := m.On("GetProblemsFromContests", []int{1}).Return(map[int][]codeforces.Problem{
+			1: {
+				{
+					Name:      "Impossible Problem",
+					ContestID: 1,
+					Index:     "D",
+					Tags:      []string{"dp", "brute force"},
+				}, {
+					Name:      "More Possible Problem",
+					ContestID: 1,
+					Index:     "B",
+					Tags:      []string{"dp", "brute force"},
+				}, {
+					Name:      "Super Easy Problem",
+					ContestID: 1,
+					Index:     "A",
+					Tags:      []string{"dp", "brute force"},
+				}, expected,
+			},
 		}, nil)
 		defer mockCall.Unset()
 
@@ -147,34 +149,36 @@ func TestFindFirstUnsolvedProblem(t *testing.T) {
 			Tags:      []string{"graph", "dsu"},
 		}
 
-		mockCall := m.On("GetProblemsFromContest", 42).Return([]codeforces.Problem{
-			{
-				Name:      "Kniv og Gaffel (Easy version)",
-				ContestID: 42,
-				Index:     "C1",
-				Tags:      []string{"graph", "dsu"},
-			}, {
-				Name:      "You should solve this",
-				ContestID: 42,
-				Index:     "A",
-				Tags:      []string{"greedy", "brute force"},
-			}, {
-				Name:      "You should also solve this",
-				ContestID: 42,
-				Index:     "B",
-				Tags:      []string{"greedy", "brute force"},
-			},
-			expected,
-			{
-				Name:      "Is this possible? (Easy)",
-				ContestID: 42,
-				Index:     "D1",
-				Tags:      []string{"greedy", "brute force"},
-			}, {
-				Name:      "Is this possible? (Hard)",
-				ContestID: 42,
-				Index:     "D2",
-				Tags:      []string{"greedy", "brute force"},
+		mockCall := m.On("GetProblemsFromContests", []int{42}).Return(map[int][]codeforces.Problem{
+			42: {
+				{
+					Name:      "Kniv og Gaffel (Easy version)",
+					ContestID: 42,
+					Index:     "C1",
+					Tags:      []string{"graph", "dsu"},
+				}, {
+					Name:      "You should solve this",
+					ContestID: 42,
+					Index:     "A",
+					Tags:      []string{"greedy", "brute force"},
+				}, {
+					Name:      "You should also solve this",
+					ContestID: 42,
+					Index:     "B",
+					Tags:      []string{"greedy", "brute force"},
+				},
+				expected,
+				{
+					Name:      "Is this possible? (Easy)",
+					ContestID: 42,
+					Index:     "D1",
+					Tags:      []string{"greedy", "brute force"},
+				}, {
+					Name:      "Is this possible? (Hard)",
+					ContestID: 42,
+					Index:     "D2",
+					Tags:      []string{"greedy", "brute force"},
+				},
 			},
 		}, nil)
 		defer mockCall.Unset()
@@ -193,24 +197,26 @@ func TestFindFirstUnsolvedProblem(t *testing.T) {
 			Tags:      []string{"graph", "dsu"},
 		}
 
-		mockCall := m.On("GetProblemsFromContest", 42).Return([]codeforces.Problem{
-			{
-				Name:      "Kniv og Gaffel (Easy version)",
-				ContestID: 42,
-				Index:     "C1",
-				Tags:      []string{"graph", "dsu"},
-			}, {
-				Name:      "You should solve this",
-				ContestID: 42,
-				Index:     "A",
-				Tags:      []string{"greedy", "brute force"},
-			}, {
-				Name:      "You should also solve this",
-				ContestID: 42,
-				Index:     "B",
-				Tags:      []string{"greedy", "brute force"},
+		mockCall := m.On("GetProblemsFromContests", []int{42}).Return(map[int][]codeforces.Problem{
+			42: {
+				{
+					Name:      "Kniv og Gaffel (Easy version)",
+					ContestID: 42,
+					Index:     "C1",
+					Tags:      []string{"graph", "dsu"},
+				}, {
+					Name:      "You should solve this",
+					ContestID: 42,
+					Index:     "A",
+					Tags:      []string{"greedy", "brute force"},
+				}, {
+					Name:      "You should also solve this",
+					ContestID: 42,
+					Index:     "B",
+					Tags:      []string{"greedy", "brute force"},
+				},
+				expected,
 			},
-			expected,
 		}, nil)
 		defer mockCall.Unset()
 


### PR DESCRIPTION
Fixes #215 

The main idea is to query the DB for problems for contests the user has solved at least one problem from, and then find the corresponding problems for each contest.
This way we guarantee that the `ContestID` and `Index` are the exact same as the problems stored in the DB, and therefore the hashes are the same as well.
See the linked issue for more details on why this fixes the problem.

Also refactored `GetProblemsFromContest` to take take a slice of IDs and return a map of contest ID to slice of problems. This is used to make the query needed for updating the contest IDs and indices faster, as we only need to run a single query.